### PR TITLE
minor improvement

### DIFF
--- a/tests/test_ai_coding_content.py
+++ b/tests/test_ai_coding_content.py
@@ -46,7 +46,7 @@ def test_guide_reference_urls_come_from_reviewed_catalog() -> None:
 
     for path in GUIDES.values():
         _, body = load_guide(path)
-        urls = set(re.findall(r"\]\((https://[^)]+)\)", body))
+        urls = set(re.findall(r"\]\((https://[^)\s]+)", body))
         assert urls
         assert urls <= catalog_urls
 


### PR DESCRIPTION
Just ignore markdown link titles when extracting guide URLs.